### PR TITLE
Newer versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@ Install [LimeChat](http://limechat.net/mac/), an IRC client for Mac OS X.
 include limechat
 ```
 
+You can specify a version:
+
+``` puppet
+class { 'limechat': version => '3.00' }
+```
+
+...or in Hiera...
+
+``` yaml
+limechat::version: '3.00'
+```
+
 ## Required Puppet Modules
 
 * `boxen`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,9 +3,11 @@
 # Examples
 #
 #  include limechat
-class limechat {
+class limechat(
+  $version = '2.42',
+){
   package { 'LimeChat':
     provider => 'compressed_app',
-    source   => 'http://surfnet.dl.sourceforge.net/project/limechat/limechat/LimeChat_2.37.tbz',
+    source   => "http://surfnet.dl.sourceforge.net/project/limechat/limechat/LimeChat_${$version}.tbz",
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,7 +4,7 @@
 #
 #  include limechat
 class limechat(
-  $url_base = 'http://surfnet.dl.sourceforge.net/project/limechat/limechat',
+  $url_base = 'http://downloads.sourceforge.net/project/limechat/limechat',
   $version = '2.42',
 ){
   package { 'LimeChat':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,10 +4,11 @@
 #
 #  include limechat
 class limechat(
+  $url_base = 'http://surfnet.dl.sourceforge.net/project/limechat/limechat',
   $version = '2.42',
 ){
   package { 'LimeChat':
     provider => 'compressed_app',
-    source   => "http://surfnet.dl.sourceforge.net/project/limechat/limechat/LimeChat_${$version}.tbz",
+    source   => "${url_base}/LimeChat_${$version}.tbz",
   }
 }

--- a/spec/classes/limechat_spec.rb
+++ b/spec/classes/limechat_spec.rb
@@ -18,4 +18,11 @@ describe 'limechat' do
     it { should contain_package('LimeChat').with_source('http://surfnet.dl.sourceforge.net/project/limechat/limechat/LimeChat_3.00.tbz') }
   end
 
+  context 'with a URL base' do
+    let(:params) { { :url_base => 'https://s3.amazonaws.com/boxen-downloads/limechat' } }
+
+    it_behaves_like 'it installs limechat'
+    it { should contain_package('LimeChat').with_source('https://s3.amazonaws.com/boxen-downloads/limechat/LimeChat_2.42.tbz') }
+  end
+
 end

--- a/spec/classes/limechat_spec.rb
+++ b/spec/classes/limechat_spec.rb
@@ -8,14 +8,14 @@ describe 'limechat' do
 
   context 'with no parameters' do
     it_behaves_like 'it installs limechat'
-    it { should contain_package('LimeChat').with_source('http://surfnet.dl.sourceforge.net/project/limechat/limechat/LimeChat_2.42.tbz') }
+    it { should contain_package('LimeChat').with_source('http://downloads.sourceforge.net/project/limechat/limechat/LimeChat_2.42.tbz') }
   end
 
   context 'with a version' do
     let(:params) { { :version => '3.00' } }
 
     it_behaves_like 'it installs limechat'
-    it { should contain_package('LimeChat').with_source('http://surfnet.dl.sourceforge.net/project/limechat/limechat/LimeChat_3.00.tbz') }
+    it { should contain_package('LimeChat').with_source('http://downloads.sourceforge.net/project/limechat/limechat/LimeChat_3.00.tbz') }
   end
 
   context 'with a URL base' do

--- a/spec/classes/limechat_spec.rb
+++ b/spec/classes/limechat_spec.rb
@@ -1,9 +1,21 @@
 require 'spec_helper'
 
 describe 'limechat' do
+  shared_examples 'it installs limechat' do
+    it { should contain_class('limechat') }
+    it { should contain_package('LimeChat').with_provider('compressed_app') }
+  end
 
-  it { should contain_class('limechat') }
-  it { should contain_package('LimeChat').with_provider('compressed_app') }
-  it { should contain_package('LimeChat').with_source('http://surfnet.dl.sourceforge.net/project/limechat/limechat/LimeChat_2.37.tbz') }
+  context 'with no parameters' do
+    it_behaves_like 'it installs limechat'
+    it { should contain_package('LimeChat').with_source('http://surfnet.dl.sourceforge.net/project/limechat/limechat/LimeChat_2.42.tbz') }
+  end
+
+  context 'with a version' do
+    let(:params) { { :version => '3.00' } }
+
+    it_behaves_like 'it installs limechat'
+    it { should contain_package('LimeChat').with_source('http://surfnet.dl.sourceforge.net/project/limechat/limechat/LimeChat_3.00.tbz') }
+  end
 
 end

--- a/spec/fixtures/Puppetfile
+++ b/spec/fixtures/Puppetfile
@@ -1,2 +1,2 @@
-mod 'boxen', '0.0.26', :github_tarball => 'boxen/puppet-boxen'
-mod 'stdlib', '3.0.0', :github_tarball => "puppetlabs/puppetlabs-stdlib"
+mod 'boxen', '3.6.0', :github_tarball => 'boxen/puppet-boxen'
+mod 'stdlib', '4.1.0', :github_tarball => "puppetlabs/puppetlabs-stdlib"


### PR DESCRIPTION
Limechat currently fails to install because the URL is outdated.

This change allows users or organisations to specify their own version or URL-base without updating the Puppet manifest.

Hopefully others will find this useful.
